### PR TITLE
Wrapper Component and Typescrpit updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,18 @@ How many pages number you want to display in pagination zone.
 
 Current page number
 
+### wrapperComponent
+
+> `React.ReactNode || string`
+
+A simple wrapper component to replace the default `div` tag
+
+### wrapperStyles
+
+> `object`
+
+A style object that is spread on the `wrapperComponent`
+
 ## Child callback functions
 
 ### getPageItemProps

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "rollup-plugin-terser": "^4.0.4",
     "sinon": "^4.0.2",
     "react-scripts": "^3.1.1",
-    "babel-eslint": "10.0.2",
+    "babel-eslint": "10.0.3",
     "eslint": "6.1.0"
   },
   "scripts": {

--- a/src/Pagination/Pagination.js
+++ b/src/Pagination/Pagination.js
@@ -25,7 +25,7 @@ function Pagination(props) {
     };
   };
 
-  const { total, limit, pageCount } = props;
+  const { total, limit, pageCount, wrapperComponent, wrapperStyles = {} } = props;
 
   const pageInfo = getPageInfo({
     limit,
@@ -38,8 +38,10 @@ function Pagination(props) {
 
   const pages = total > 0 ? getRange(firstPage, lastPage) : [];
 
+  const Wrapper = wrapperComponent || 'div';
+
   return (
-    <div>
+    <Wrapper {...wrapperStyles}>
       {props.children({
         pages,
         previousPage,
@@ -50,7 +52,7 @@ function Pagination(props) {
         hasPreviousPage,
         getPageItemProps: _getPageItemProps
       })}
-    </div>
+    </Wrapper>
   );
 }
 
@@ -61,7 +63,9 @@ Pagination.propTypes = {
   currentPage: PropTypes.number,
   pageValue: PropTypes.number,
   children: PropTypes.func.isRequired,
-  onPageChange: PropTypes.func
+  onPageChange: PropTypes.func,
+  wrapperComponent: PropTypes.element,
+  wrapperStyles: PropTypes.object
 };
 
 Pagination.defaultProps = {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,6 +1,9 @@
 import * as React from 'react';
 
-export type PaginationItemProps<T extends HTMLElement = HTMLElement> = Omit<PaginationProps, 'children'> &
+export type PaginationItemProps<T extends HTMLElement = HTMLElement> = Omit<
+  PaginationProps,
+  'children' | 'total' | 'wrapperComponent'
+> &
   React.HTMLAttributes<T>;
 
 export interface PaginationState {
@@ -24,6 +27,8 @@ export interface PaginationProps {
   currentPage?: number;
   pageValue?: number;
   onPageChange?: (page?: number, event?: React.MouseEvent) => void;
+  wrapperComponent?: React.ReactNode;
+  wrapperStyles?: { [key: string]: string | { [key: string]: string } };
 }
 
 declare const Pagination: React.ComponentType<PaginationProps>;


### PR DESCRIPTION
This PR adds in the option to use a wrapper component instead of an arbitrary `div` tag. It also allows for the wrapper component to take a `wrapperStyles` object that will allow for either a styled-component or a regular inline style object for react.